### PR TITLE
Suggested changes for pimatic 0.9 readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ But you can define your own, using a variable name returned by de NUT server. In
 
 ### NUT variables
 
-if you want to define your own attribute using a NUT variable, you should do this to get the list of available variables for your UPS:
+If you want to define your own attribute using a NUT variable, you should do this to get the list of available variables for your UPS:
 
 ```
 $ echo "LIST VAR myups" | nc localhost 3493
@@ -78,7 +78,7 @@ Add this to your `config.json`:
     "nutport": 3493,
     "upsid": "myups1",
     "attributes": [
-        {"
+        {
           "name": "status"
         },
         {
@@ -113,7 +113,7 @@ Add this to your `config.json`:
     "nutport": 3493,
     "upsid": "myups2",
     "attributes": [
-        {"
+        {
           "name": "status"
         },
         {

--- a/device-config-schema.coffee
+++ b/device-config-schema.coffee
@@ -54,8 +54,8 @@ module.exports = {
               type: "boolean"
               required: false
             labels:
-              description: "Labels assigned to attribute values"
-              type: "boolean"
+              description: "Labels assigned to attribute values. Don't set. Will be set at runtime"
+              type: "array"
               required: false
   }
 }

--- a/device-config-schema.coffee
+++ b/device-config-schema.coffee
@@ -10,6 +10,7 @@ module.exports = {
       nutport:
         description: "NUT server port"
         type: "number"
+        default: 3493
       upsid:
         description: "UPS ID"
         type: "string"
@@ -30,14 +31,14 @@ module.exports = {
               default: 60000
             var:
               type: "string"
-              description: "Required if an attribute is defined other than batteryCharge, inputVoltage, load, or status"
+              description: "The corresponding NUT variable. Required if an attribute is defined other than batteryCharge, inputVoltage, load, or status"
               required: false
             type:
-              description: "The type of the value"
+              description: "The type of the value. Required if an attribute is defined other than batteryCharge, inputVoltage, load, or status"
               type: "string"
               required: false
             description:
-              description: "A description provided for the attribute"
+              description: "A description provided for the attribute. Don't set. Will be set at runtime"
               type: "string"
               required: false
             acronym:
@@ -45,7 +46,7 @@ module.exports = {
               type: "string"
               required: false
             unit:
-              description: "The unit to show in the frontend"
+              description: "The unit to show in the frontend. Required if an attribute is defined other than batteryCharge, inputVoltage, load, or status"
               type: "string"
               required: false
             discrete:

--- a/device-config-schema.coffee
+++ b/device-config-schema.coffee
@@ -16,5 +16,45 @@ module.exports = {
       attributes:
         description: "Attributes of the device"
         type: "array"
+        format: "table"
+        default: [{name: "status"}]
+        items:
+          type: "object"
+          properties:
+            name:
+              type: "string"
+              description: "The name of the attribute"
+            interval:
+              type: "number"
+              description: "The update interval in ms"
+              default: 60000
+            var:
+              type: "string"
+              description: "Required if an attribute is defined other than batteryCharge, inputVoltage, load, or status"
+              required: false
+            type:
+              description: "The type of the value"
+              type: "string"
+              required: false
+            description:
+              description: "A description provided for the attribute"
+              type: "string"
+              required: false
+            acronym:
+              description: "Acronym to show as value label in the frontend"
+              type: "string"
+              required: false
+            unit:
+              description: "The unit to show in the frontend"
+              type: "string"
+              required: false
+            discrete:
+              description: "Set to true if the value does not change continuously over time"
+              type: "boolean"
+              required: false
+            labels:
+              description: "Labels assigned to attribute values"
+              type: "boolean"
+              required: false
   }
 }

--- a/nut.coffee
+++ b/nut.coffee
@@ -125,6 +125,9 @@ module.exports = (env) ->
       oNut.on('ready', () ->
           this.GetUPSVars(upsid, get_data)
       )
+      oNut.on('error', (error) ->
+        env.logger.error error.message ? error
+      )
       oNut.start()
 
   # ###Finally

--- a/nut.coffee
+++ b/nut.coffee
@@ -21,8 +21,8 @@ module.exports = (env) ->
   class NutSensor extends env.devices.Sensor
 
     constructor: (@config) ->
-      @name = config.name
-      @id = config.id
+      @name = @config.name
+      @id = @config.id
 
       @attributes = {}
       @upsvars = []
@@ -110,7 +110,7 @@ module.exports = (env) ->
 
       if @attributes
         setInterval( ( =>
-          @readUPSData(config.nutport or 3493, config.nuthost or 'localhost', config.upsid)
+          @readUPSData(@config.nutport or 3493, @config.nuthost or 'localhost', @config.upsid)
         ), min_interval)
 
       super()

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "pimatic-nut",
   "description": "Provides NUT (Network UPS Tools) info to Pimatic",
   "author": "Antonio Pérez <aperez@skarcha.com>",
+  "license": "MIT",
   "main": "nut",
   "files": [
     "nut.coffee",
@@ -21,7 +22,7 @@
     "node-nut": "0.1.0"
   },
   "peerDependencies": {
-    "pimatic": "0.8.*"
+    "pimatic": ">=0.8.0 <1.0.0"
   },
   "engines": {
     "node": ">0.8.x",


### PR DESCRIPTION
A couple of changes are required to run your plugin with the upcoming pimatic 0.9 release. All changes done _should be backwards compatible_. However, _please test thoroughly_ with your setup as I don't have the hardware in place. I have also extended the device config schema to improve the user experience with the new device editor provided with pimatic 0.9
